### PR TITLE
Handle errors during kill() in Linux so that WebIDE can see the proper e...

### DIFF
--- a/lib/util/ios-proxy.js
+++ b/lib/util/ios-proxy.js
@@ -210,7 +210,11 @@ let iOSProxy = {
 
   stop() {
     if (proxyProcess) {
-      proxyProcess.kill();
+      try {
+        proxyProcess.kill();
+      } catch (e) {
+        console.log("Ignoring error while killing process:", e);
+      }
       proxyProcess = null;
     }
   }


### PR DESCRIPTION
...rror

Without this patch, trying to use the "Safari on iOS" runtime on Linux without having a device connected will display a confusing error message.